### PR TITLE
Add dark mode support to default SVG theme

### DIFF
--- a/src/renderer/theme/awesome-card.ts
+++ b/src/renderer/theme/awesome-card.ts
@@ -6,13 +6,13 @@ export interface Theme {
 }
 
 export const themes: Record<string, Theme> = {
-  light: {
+  default: {
     quote: '333',
     author: '2f80ed',
     background: 'fffefe',
     symbol: '4c71f2'
   },
-  dark: {
+  defaultDarkModeSupport: {
     quote: '9f9f9f',
     author: 'fff',
     background: '151515',
@@ -123,11 +123,11 @@ export const themes: Record<string, Theme> = {
 };
 
 export const renderTheme = (theme: keyof typeof themes) => {
-  // Check if theme exists in the themes object
-  if (themes[theme]) {
+  // Check if theme exists in the themes object and is neither default light nor dark mode theme
+  if (themes[theme] && theme !== 'light' && theme !== 'dark') {
     return themes[theme];
   }
 
-  // Else, return the light theme
-  return themes.light;
+  // Else, return the default (light) theme with dark mode support
+  return themes.default;
 };

--- a/src/renderer/type/horizontal-card.ts
+++ b/src/renderer/type/horizontal-card.ts
@@ -1,5 +1,5 @@
 import { poppinsFontSVG } from '../constants';
-import { Theme } from '../theme/awesome-card';
+import { Theme, themes } from '../theme/awesome-card';
 
 interface Props {
   quote: string;
@@ -24,7 +24,6 @@ export const renderHorizontal = ({ quote, author, color }: Props) => {
                   font-family: Poppins, Arial, Helvetica, sans-serif;
                   padding: 20px;
                   width: 600px;
-                  background-color: #${color.background};
                   border: 1px solid rgba(0, 0, 0, 0.2);
                   border-radius: 10px;
                 }
@@ -33,25 +32,68 @@ export const renderHorizontal = ({ quote, author, color }: Props) => {
                   margin-bottom: 5px;
                   font-weight: 500;
                   font-style: oblique;
-                  color: #${color.quote};
                 }
                 .container h3::before {
                   content: open-quote;
                   font-size: 25px;
-                  color: #${color.symbol};
                 }
                 .container h3::after {
                   content: close-quote;
                   vertical-align: sub;
                   font-size: 25px;
-                  color: #${color.symbol};
                 }
                 .container p {
                   font-style: italic;
                   padding: 5px;
                   text-align: right;
-                  color: #${color.author};
                 }
+                
+                /* Default light theme */
+                .container {
+                  background-color: #${themes.default.background};
+                }
+                .container h3 {
+                  color: #${themes.default.quote};
+                }
+                .container h3::before, .container h3::after {
+                  color: #${themes.default.symbol};
+                }
+                .container p {
+                  color: #${themes.default.author};
+                }
+            
+                /* Default dark theme - iff dark mode detected in system settings, overriding default light theme */
+                @media (prefers-color-scheme: dark) {
+                  .container {
+                    background-color: #${themes.defaultDarkModeSupport.background};
+                  }
+                  .container h3 {
+                    color: #${themes.defaultDarkModeSupport.quote};
+                  }
+                  .container h3::before, .container h3::after {
+                    color: #${themes.defaultDarkModeSupport.symbol};
+                  }
+                  .container p {
+                    color: #${themes.defaultDarkModeSupport.author};
+                  }
+                }
+            
+                /* Default light/dark mode theme override for any custom theme */
+                ${JSON.stringify(color) !== JSON.stringify(themes.default) && 
+                  JSON.stringify(color) !== JSON.stringify(themes.defaultDarkModeSupport) ? 
+                ` .container {
+                    background-color: #${color.background};
+                  }
+                  .container h3 {
+                    color: #${color.quote};
+                  }
+                  .container h3::before, .container h3::after {
+                    color: #${color.symbol};
+                  }
+                  .container p {
+                    color: #${color.author};
+                  }
+                ` : ''}
             </style>
 
             <div class="container">

--- a/src/renderer/type/vertical-card.ts
+++ b/src/renderer/type/vertical-card.ts
@@ -1,6 +1,5 @@
 import { poppinsFontSVG } from '../constants';
-
-import type { Theme } from '../theme/awesome-card';
+import { Theme, themes } from '../theme/awesome-card';
 
 interface Props {
   quote: string;
@@ -24,7 +23,6 @@ export const renderVertical = ({ quote, author, color }: Props) => {
           .container {
             width: 300px;
             height: 300px;
-            background-color: #${color.background};
             font-family: Poppins, Arial, Helvetica, sans-serif;
             padding: 15px;
             display:flex;
@@ -37,11 +35,9 @@ export const renderVertical = ({ quote, author, color }: Props) => {
           }
           .container h3::before {
             content: open-quote;
-            color: #${color.symbol};
           }
           .container h3::after {
             content: close-quote;
-            color: #${color.symbol};
           }
           .container h3::before, .container h3::after {
             font-size: 50px;
@@ -51,12 +47,57 @@ export const renderVertical = ({ quote, author, color }: Props) => {
           }
           .container h3 {
             margin-bottom: 15px;
-            color: #${color.quote};
           }
           .container p {
             font-style: italic;
-            color: #${color.author};
           }
+          
+          /* Default light theme */
+          .container {
+            background-color: #${themes.default.background};
+          }
+          .container h3 {
+            color: #${themes.default.quote};
+          }
+          .container h3::before, .container h3::after {
+            color: #${themes.default.symbol};
+          }
+          .container p {
+            color: #${themes.default.author};
+          }
+      
+          /* Default dark theme - iff dark mode detected in system settings, overriding default light theme */
+          @media (prefers-color-scheme: dark) {
+            .container {
+              background-color: #${themes.defaultDarkModeSupport.background};
+            }
+            .container h3 {
+              color: #${themes.defaultDarkModeSupport.quote};
+            }
+            .container h3::before, .container h3::after {
+              color: #${themes.defaultDarkModeSupport.symbol};
+            }
+            .container p {
+              color: #${themes.defaultDarkModeSupport.author};
+            }
+          }
+      
+          /* Default light/dark mode theme override for any custom theme */
+          ${JSON.stringify(color) !== JSON.stringify(themes.default) &&
+            JSON.stringify(color) !== JSON.stringify(themes.defaultDarkModeSupport) ?
+          ` .container {
+              background-color: #${color.background};
+            }
+            .container h3 {
+              color: #${color.quote};
+            }
+            .container h3::before, .container h3::after {
+              color: #${color.symbol};
+            }
+            .container p {
+              color: #${color.author};
+            }
+          ` : ''}
         </style>
         <div class="container">
           <h3>${quote}</h3>


### PR DESCRIPTION
Fixes #35 

Added CSS `prefers-color-scheme` media feature to both horizontal and vertical SVG card rendering so that user system setting defines light or dark mode by default. This is overridden if any other custom theme that is neither 'light' nor 'dark' is being used:

```
/* Default light theme */
.container {
  background-color: #${themes.default.background};
}
.container h3 {
  color: #${themes.default.quote};
}
.container h3::before, .container h3::after {
  color: #${themes.default.symbol};
}
.container p {
  color: #${themes.default.author};
}

/* Default dark theme - iff dark mode detected in system settings, overriding default light theme */
@media (prefers-color-scheme: dark) {
  .container {
    background-color: #${themes.defaultDarkModeSupport.background};
  }
  .container h3 {
    color: #${themes.defaultDarkModeSupport.quote};
  }
  .container h3::before, .container h3::after {
    color: #${themes.defaultDarkModeSupport.symbol};
  }
  .container p {
    color: #${themes.defaultDarkModeSupport.author};
  }
}

/* Default light/dark mode theme override for any custom theme */
${JSON.stringify(color) !== JSON.stringify(themes.default) && 
  JSON.stringify(color) !== JSON.stringify(themes.defaultDarkModeSupport) ? 
` .container {
    background-color: #${color.background};
  }
  .container h3 {
    color: #${color.quote};
  }
  .container h3::before, .container h3::after {
    color: #${color.symbol};
  }
  .container p {
    color: #${color.author};
  }
` : ''}
```

Other modifications include:

```
export const renderTheme = (theme: keyof typeof themes) => {
  // Check if theme exists in the themes object and is neither default light nor dark mode theme
  if (themes[theme] && theme !== 'light' && theme !== 'dark') {
    return themes[theme];
  }

  // Else, return the default (light) theme with dark mode support
  return themes.default;
};
```

and name changes from `light` and `dark` themes to `default` and `defaultDarkModeSupport`, respectively.

## Testing

The changes are manually tested with the following results:

### GitHub dark default setting:

[![manualTest](https://github.com/PiyushSuthar/github-readme-quotes/assets/14985050/ba1f1839-f84a-4b15-bd5f-f57eb236cd6e)](https://github.com/R055A/github-readme-quotes/tree/test)

### GitHub light default setting:

[![lightMode](https://github.com/PiyushSuthar/github-readme-quotes/assets/14985050/f88a2298-a802-40ad-935c-cd4d5c33a111)](https://github.com/R055A/github-readme-quotes/tree/test)

## Note

No changes are made to the `README.md` instructions as it is unknown how this is wanted to be updated