### PR TITLE
Added support for border which can be enabled by setting border=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Copy the markdown below and paste it in your Github Readme.
 | theme   | light    | dark, chartreuse-dark, radical, merko, gruvbox, tokyonight, algolia, monokai, dracula, nord |
 | quote   | -        | Customize your quote                                                                        |
 | author  | -        | The name of the quote's author                                                              |
+| border  | false    | true, false                                                                                 |
 
 ## Installation and Development 🚀
 
@@ -78,6 +79,12 @@ npx vercel dev
 > You need to add **?type=horizontal** parameter.
 
 [![readme Quotes](https://quotes-github-readme.vercel.app/api?type=horizontal)](https://github.com/piyushsuthar/github-readme-quotes)
+
+### Border
+
+> You need to add **?border=true** parameter.
+
+[![readme Quotes](https://quotes-github-readme.vercel.app/api?border=true)](https://github.com/piyushsuthar/github-readme-quotes)
 
 ### Light
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -11,10 +11,11 @@ interface ResponseQuery {
   theme: keyof typeof themes;
   quote: string;
   author: string;
+  border: boolean;
 }
 
 const handler = async (req: VercelRequest, res: VercelResponse) => {
-  const { type, theme, quote, author } = req.query as unknown as ResponseQuery;
+  const { type, theme, quote, author, border } = req.query as unknown as ResponseQuery;
 
   let data;
 
@@ -35,7 +36,7 @@ const handler = async (req: VercelRequest, res: VercelResponse) => {
   // Send the quote image response.
   res.setHeader('Content-Type', 'image/svg+xml');
   res.setHeader('Cache-Control', `public, max-age=600`);
-  res.send(renderSVG(data, type, theme));
+  res.send(renderSVG(data, type, theme, border));
 };
 
 export default handler;

--- a/src/renderer/render-svg.ts
+++ b/src/renderer/render-svg.ts
@@ -7,7 +7,8 @@ export type CardType = 'vertical' | 'horizontal' | undefined;
 export const renderSVG = (
   data: { quote: string; author: string },
   type: CardType,
-  theme: keyof typeof themes
+  theme: keyof typeof themes,
+  border: boolean
 ) => {
   const { quote, author } = data;
 
@@ -17,10 +18,10 @@ export const renderSVG = (
 
   switch (type) {
     case 'vertical':
-      return renderVertical({ quote, author, color });
+      return renderVertical({ quote, author, color, border });
     case 'horizontal':
-      return renderHorizontal({ quote, author, color });
+      return renderHorizontal({ quote, author, color, border });
     default:
-      return renderVertical({ quote, author, color });
+      return renderVertical({ quote, author, color, border });
   }
 };

--- a/src/renderer/theme/awesome-card.ts
+++ b/src/renderer/theme/awesome-card.ts
@@ -124,7 +124,7 @@ export const themes: Record<string, Theme> = {
     quote: '00B3D6',
     author: '00B3D6',
     background: '000000',
-    symbol: '0B3D6'
+    symbol: '00B3D6'
   }
 };
 

--- a/src/renderer/type/horizontal-card.ts
+++ b/src/renderer/type/horizontal-card.ts
@@ -5,9 +5,10 @@ interface Props {
   quote: string;
   author: string;
   color: Theme;
+  border: boolean;
 }
 
-export const renderHorizontal = ({ quote, author, color }: Props) => {
+export const renderHorizontal = ({ quote, author, color, border }: Props) => {
   const renderedSVG = `
   <svg width="600" height="auto" fill="none" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
@@ -24,7 +25,7 @@ export const renderHorizontal = ({ quote, author, color }: Props) => {
                   font-family: Poppins, Arial, Helvetica, sans-serif;
                   padding: 20px;
                   width: 600px;
-                  border: 1px solid rgba(0, 0, 0, 0.2);
+                  border: ${border ? "3px solid #"+themes.default.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
                   border-radius: 10px;
                 }
                 .container h3 {
@@ -66,6 +67,7 @@ export const renderHorizontal = ({ quote, author, color }: Props) => {
                 @media (prefers-color-scheme: dark) {
                   .container {
                     background-color: #${themes.defaultDarkModeSupport.background};
+				  	border: ${border ? "3px solid #"+themes.defaultDarkModeSupport.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
                   }
                   .container h3 {
                     color: #${themes.defaultDarkModeSupport.quote};
@@ -83,6 +85,7 @@ export const renderHorizontal = ({ quote, author, color }: Props) => {
                   JSON.stringify(color) !== JSON.stringify(themes.defaultDarkModeSupport) ? 
                 ` .container {
                     background-color: #${color.background};
+					border: ${border ? "3px solid #"+color.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
                   }
                   .container h3 {
                     color: #${color.quote};

--- a/src/renderer/type/vertical-card.ts
+++ b/src/renderer/type/vertical-card.ts
@@ -5,9 +5,10 @@ interface Props {
   quote: string;
   author: string;
   color: Theme;
+  border: boolean;
 }
 
-export const renderVertical = ({ quote, author, color }: Props) => {
+export const renderVertical = ({ quote, author, color, border }: Props) => {
   const renderedSVG = `
   <svg width="300" height="300" fill="none" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
@@ -30,7 +31,7 @@ export const renderVertical = ({ quote, author, color }: Props) => {
             align-items:center;
             justify-content:center;
             text-align:center;
-            border: 1px solid rgba(0,0,0,0.1);
+		  	border: ${border ? "3px solid #"+themes.default.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
             border-radius: 10px;
           }
           .container h3::before {
@@ -70,6 +71,7 @@ export const renderVertical = ({ quote, author, color }: Props) => {
           @media (prefers-color-scheme: dark) {
             .container {
               background-color: #${themes.defaultDarkModeSupport.background};
+			  border: ${border ? "3px solid #"+themes.defaultDarkModeSupport.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
             }
             .container h3 {
               color: #${themes.defaultDarkModeSupport.quote};
@@ -87,6 +89,7 @@ export const renderVertical = ({ quote, author, color }: Props) => {
             JSON.stringify(color) !== JSON.stringify(themes.defaultDarkModeSupport) ?
           ` .container {
               background-color: #${color.background};
+			  border: ${border ? "3px solid #"+color.symbol : "1px solid rgba(0, 0, 0, 0.2)"};
             }
             .container h3 {
               color: #${color.quote};


### PR DESCRIPTION
A border can be added in the color of the symbol to the quote by setting `border=true`

![image](https://github.com/PiyushSuthar/github-readme-quotes/assets/75056416/c95d787d-709d-41e5-84f2-7381c5045bef)


![image](https://github.com/PiyushSuthar/github-readme-quotes/assets/75056416/612ab11e-8cd8-4572-8875-8037b75f00f3)

![quote](https://quotes-github-readme-git-fork-ananth-swamy-border-piyushsuthar.vercel.app/api?border=true)

![quote](https://quotes-github-readme-git-fork-ananth-swamy-border-piyushsuthar.vercel.app/api?border=true&type=horizontal)
